### PR TITLE
Reject promise on unsuccessful AJAX requests

### DIFF
--- a/opal/bowser/http.rb
+++ b/opal/bowser/http.rb
@@ -52,7 +52,11 @@ module Bowser
 
     def connect_events_to_promise(request, promise)
       request.on :load do
-        promise.resolve request.response
+        if request.response.success?
+          promise.resolve request.response
+        else
+          promise.reject request.response
+        end
       end
       request.on :error do |event|
         promise.reject Native(event)


### PR DESCRIPTION
Consider the following request:

``` ruby
Bowser::HTTP.fetch('/api/widgets')
  .then { |response| handle_success(response) }
  .fail { |failure| handle_failure(failure) }
```

Currently, a 4xx-5xx response will invoke the `then` block and that surprised me. I thought failure responses didn't trigger the `load` event on XHR (which is what we're using to resolve the promise), but instead triggered the `error` event, but apparently I was mistaken.

This may be a breaking change, but because I also thought this was how this worked at one point, this might actually fix a regression. Because I'm not sure, I'm hoping someone else is using this that may have thoughts on it?

/cc @jdickey
