### PR TITLE
Add request upload object

### DIFF
--- a/opal/bowser/http/form_data.rb
+++ b/opal/bowser/http/form_data.rb
@@ -1,8 +1,17 @@
 module Bowser
   module HTTP
     class FormData
-      def initialize
+      def initialize attributes={}
         @native = `new FormData()`
+        attributes.each do |key, value|
+          if `!!value.$$class` && value.respond_to?(:each)
+            value.each do |item|
+              append "#{key}[]", item
+            end
+          else
+            append key, value
+          end
+        end
       end
 
       def append key, value

--- a/opal/bowser/http/request.rb
+++ b/opal/bowser/http/request.rb
@@ -74,6 +74,18 @@ module Bowser
       def done?
         ready_state >= DONE
       end
+
+      def upload
+        @upload ||= Upload.new(`#@native.upload`)
+      end
+
+      class Upload
+        include EventTarget
+
+        def initialize(native)
+          @native = native
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This lets us do things like:

```ruby
request = Bowser::HTTP::Request.new(:post, url)

request.upload.on(:progress) { |event| store.dispatch UploadProgress.new(event.loaded / event.total) }
request.upload.on(:load) { store.dispatch UploadFinished.new } # finished sending file
request.on(:load) { |event| store.dispatch UploadComplete.new } # finished receiving response

request.send(data: FormData.new(file: @file))
```