### PR TITLE
Allow HTTP methods to yield request for customization

### DIFF
--- a/opal/bowser/http.rb
+++ b/opal/bowser/http.rb
@@ -8,29 +8,31 @@ module Bowser
   module HTTP
     module_function
 
-    def fetch(url, method: :get, headers: {}, data: nil)
+    def fetch(url, method: :get, headers: {}, data: nil, &block)
       promise = Promise.new
       request = Request.new(method, url)
 
       connect_events_to_promise request, promise
 
+      block.call(request) if block_given?
       request.send(data: data, headers: headers)
 
       promise
     end
 
-    def upload(url, data, content_type: 'application/json', method: :post)
+    def upload(url, data, content_type: 'application/json', method: :post, &block)
       promise = Promise.new
       request = Request.new(method, url)
 
       connect_events_to_promise request, promise
 
+      block.call(request) if block_given?
       request.send(data: data, headers: { 'Content-Type' => content_type })
 
       promise
     end
 
-    def upload_files(url, files, key: 'files', key_suffix: '[]', method: :post)
+    def upload_files(url, files, key: 'files', key_suffix: '[]', method: :post, &block)
       promise = Promise.new
       request = Request.new(method, url)
 
@@ -41,13 +43,14 @@ module Bowser
         form.append "#{key}#{key_suffix}", file
       end
 
+      block.call(request) if block_given?
       request.send(data: form)
 
       promise
     end
 
-    def upload_file(url, file, key: 'file', method: :post)
-      upload_files(url, [file], key: key, key_suffix: nil, method: method)
+    def upload_file(url, file, key: 'file', method: :post, &block)
+      upload_files(url, [file], key: key, key_suffix: nil, method: method, &block)
     end
 
     def connect_events_to_promise(request, promise)

--- a/spec/bowser/http_spec.rb
+++ b/spec/bowser/http_spec.rb
@@ -1,0 +1,16 @@
+require 'bowser/http'
+
+module Bowser
+  RSpec.describe HTTP do
+    let(:request) { double("request").as_null_object }
+    before { allow(HTTP::Request).to receive(:new) { request } }
+
+    specify 'methods yield request when block is given' do
+      expect { |b| HTTP.fetch(:url, &b) }.to yield_with_args(request)
+      expect { |b| HTTP.upload(:url, :data, &b) }.to yield_with_args(request)
+      expect { |b| HTTP.upload_files(:url, [], &b) }.to yield_with_args(request)
+      expect { |b| HTTP.upload_file(:url, :file, &b) }.to yield_with_args(request)
+    end
+  end
+end
+


### PR DESCRIPTION
This change allows further customization to the request before it is sent, while still taking advantage of the HTTP module's promise attached helper methods.

For example, attaching a progress event listener:
```ruby
Bowser::HTTP.upload_file("the.internet.com", file) do |request|
  request.upload.on(:progress) { |event| ... }
end
```