### PR TITLE
Add subscript operators for get/setAttribute

### DIFF
--- a/opal/bowser/element.rb
+++ b/opal/bowser/element.rb
@@ -84,6 +84,14 @@ module Bowser
       `#@native === #{other.to_n}`
     end
 
+    def []= attribute, value
+      `#@native.setAttribute(#{attribute}, #{value})`
+    end
+
+    def [] attribute
+      `#@native.getAttribute(#{attribute})`
+    end
+
     def to_n
       @native
     end

--- a/spec/bowser/element_spec.rb
+++ b/spec/bowser/element_spec.rb
@@ -82,5 +82,19 @@ module Bowser
         expect(element == other).to be_falsey
       end
     end
+
+    describe 'attributes' do
+      it 'sets and gets attributes' do
+        native = `{
+          attributes: {},
+          setAttribute: function(attr, value) { this.attributes[attr] = value },
+          getAttribute: function(attr) { return this.attributes[attr] },
+        }`
+        element = Element.new(native)
+
+        element[:class] = 'foo bar'
+        expect(element[:class]).to eq 'foo bar'
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR allows us to get/set native-element attributes (not properties) using `Element#[]` and `#[]=`. The difference between the elements and properties APIs is probably the most ridiculous thing in front-end web development, but there are some things that can only be done feasibly using one or the other, so we should support it. :-)